### PR TITLE
Rework `measure!` macro to allow `&mut self` in expr being measured

### DIFF
--- a/demos/demo-nightly/src/boz.rs
+++ b/demos/demo-nightly/src/boz.rs
@@ -1,0 +1,22 @@
+use metered::{metered, HitCount};
+
+#[derive(Default, Debug, serde::Serialize)]
+pub struct Boz {
+    inc: i32,
+    metrics: BozMetrics,
+}
+
+#[metered(registry = BozMetrics)]
+impl Boz {
+
+    #[measure(HitCount)]
+    pub fn increment_once(&mut self) {
+        self.inc +=1;
+    }
+
+    #[measure(HitCount)]
+    pub fn increment_twice(&mut self) {
+        self.increment_once();
+        self.increment_once();
+    }
+}

--- a/demos/demo-nightly/src/main.rs
+++ b/demos/demo-nightly/src/main.rs
@@ -12,10 +12,8 @@ struct TestMetrics {
 }
 
 fn test(should_fail: bool, metrics: &TestMetrics) -> Result<(), ()> {
-    let hit_count = &metrics.hit_count;
-    let error_count = &metrics.error_count;
-    measure!(hit_count, {
-        measure!(error_count, {
+    measure!(&metrics.hit_count, {
+        measure!(&metrics.error_count, {
             println!("test !");
             if should_fail {
                 Err(())

--- a/demos/demo-nightly/src/main.rs
+++ b/demos/demo-nightly/src/main.rs
@@ -4,6 +4,8 @@ mod baz;
 use baz::Baz;
 mod biz;
 use biz::Biz;
+mod boz;
+use boz::Boz;
 
 #[derive(Default, Debug, serde::Serialize)]
 struct TestMetrics {
@@ -32,21 +34,27 @@ fn sync_procmacro_demo(baz: &Baz) {
 }
 
 async fn async_procmacro_demo(baz: Baz) {
+    println!("\nRunning Baz async procedural macro demo...");
+
     for i in 1..=5 {
         let _ = baz.baz(i % 3 == 0).await;
     }
 
     // Print the results!
+    println!("Done! Here are the metrics:");
     let serialized = serde_yaml::to_string(&baz).unwrap();
     println!("{}", serialized);
 }
 
 fn simple_api_demo() {
-    let metrics = TestMetrics::default();
+    println!("\nRunning simple `measure!` api demo...");
 
+    let metrics = TestMetrics::default();
     let _ = test(false, &metrics);
     let _ = test(true, &metrics);
+
     // Print the results!
+    println!("Done! Here are the metrics:");
     let serialized = serde_yaml::to_string(&metrics).unwrap();
     println!("{}", serialized);
 }
@@ -54,8 +62,9 @@ fn simple_api_demo() {
 use std::sync::Arc;
 use std::thread;
 
-fn test_biz() {
-    println!("Running Biz throughput demo...(will take 20 seconds)");
+fn test_biz_throughput() {
+    println!("\nRunning Biz throughput demo... (will take 20 seconds)");
+
     let biz = Arc::new(Biz::default());
     let mut threads = Vec::new();
     for _ in 0..5 {
@@ -70,20 +79,36 @@ fn test_biz() {
     for t in threads {
         t.join().unwrap();
     }
-    println!("Running Biz throughput demo... done! Here are the metrics for that run:");
+
     // Print the results!
+    println!("Done! Here are the metrics:");
     let serialized = serde_yaml::to_string(&*biz).unwrap();
+    println!("{}", serialized);
+}
+
+fn test_boz_using_mutible_self() {
+    println!("\nRunning Boz mutible self demo...");
+
+    let mut boz = Boz::default();
+    boz.increment_once();
+    boz.increment_twice();
+
+    // Print the results!
+    println!("Done! Here are the metrics:");
+    let serialized = serde_yaml::to_string(&boz).unwrap();
     println!("{}", serialized);
 }
 
 fn main() {
     simple_api_demo();
 
-    test_biz();
+    test_boz_using_mutible_self();
+
+    test_biz_throughput();
 
     let baz = Baz::default();
-
     sync_procmacro_demo(&baz);
+
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async_procmacro_demo(baz));
 }

--- a/demos/demo-stable/src/biz.rs
+++ b/demos/demo-stable/src/biz.rs
@@ -2,7 +2,6 @@ use metered::{metered, HitCount, Throughput};
 
 #[derive(Default, Debug, serde::Serialize)]
 pub struct Biz {
-    inc: i32,
     metrics: BizMetrics,
 }
 

--- a/demos/demo-stable/src/biz.rs
+++ b/demos/demo-stable/src/biz.rs
@@ -2,6 +2,7 @@ use metered::{metered, HitCount, Throughput};
 
 #[derive(Default, Debug, serde::Serialize)]
 pub struct Biz {
+    inc: i32,
     metrics: BizMetrics,
 }
 
@@ -14,5 +15,4 @@ impl Biz {
         let delay = std::time::Duration::from_millis(rand::random::<u64>() % 200);
         std::thread::sleep(delay);
     }
-
 }

--- a/demos/demo-stable/src/boz.rs
+++ b/demos/demo-stable/src/boz.rs
@@ -1,0 +1,22 @@
+use metered::{metered, HitCount};
+
+#[derive(Default, Debug, serde::Serialize)]
+pub struct Boz {
+    inc: i32,
+    metrics: BozMetrics,
+}
+
+#[metered(registry = BozMetrics)]
+impl Boz {
+
+    #[measure(HitCount)]
+    pub fn increment_once(&mut self) {
+        self.inc +=1;
+    }
+
+    #[measure(HitCount)]
+    pub fn increment_twice(&mut self) {
+        self.increment_once();
+        self.increment_once();
+    }
+}

--- a/demos/demo-stable/src/main.rs
+++ b/demos/demo-stable/src/main.rs
@@ -3,6 +3,8 @@ mod baz;
 use baz::Baz;
 mod biz;
 use biz::Biz;
+mod boz;
+use boz::Boz;
 
 #[derive(Default, Debug, serde::Serialize)]
 struct TestMetrics {
@@ -11,10 +13,8 @@ struct TestMetrics {
 }
 
 fn test(should_fail: bool, metrics: &TestMetrics) -> Result<(), ()> {
-    let hit_count = &metrics.hit_count;
-    let error_count = &metrics.error_count;
-    measure!(hit_count, {
-        measure!(error_count, {
+    measure!(&metrics.hit_count, {
+        measure!(&metrics.error_count, {
             println!("test !");
             if should_fail {
                 Err(())
@@ -26,18 +26,27 @@ fn test(should_fail: bool, metrics: &TestMetrics) -> Result<(), ()> {
 }
 
 fn sync_procmacro_demo(baz: &Baz) {
+    println!("\nRunning Baz sync procedural macro demo...");
+
     for i in 1..=10 {
         baz.foo();
         let _ = baz.bar(i % 3 == 0);
     }
+
+    println!("Done! Here are the metrics:");
+    let serialized = serde_yaml::to_string(&baz).unwrap();
+    println!("{}", serialized);
 }
 
 fn simple_api_demo() {
-    let metrics = TestMetrics::default();
+    println!("\nRunning simple `measure!` api demo...");
 
+    let metrics = TestMetrics::default();
     let _ = test(false, &metrics);
     let _ = test(true, &metrics);
+
     // Print the results!
+    println!("Done! Here are the metrics:");
     let serialized = serde_yaml::to_string(&metrics).unwrap();
     println!("{}", serialized);
 }
@@ -45,8 +54,9 @@ fn simple_api_demo() {
 use std::thread;
 use std::sync::Arc;
 
-fn test_biz() {
-    println!("Running Biz throughput demo...(will take 20 seconds)");
+fn test_biz_throughput() {
+    println!("\nRunning Biz throughput demo... (will take 20 seconds)");
+
     let biz = Arc::new(Biz::default());
     let mut threads = Vec::new();
     for _ in 0..5 {
@@ -61,18 +71,33 @@ fn test_biz() {
     for t in threads {
         t.join().unwrap();
     }
-    println!("Running Biz throughput demo... done! Here are the metrics for that run:");
+
     // Print the results!
+    println!("Done! Here are the metrics:");
     let serialized = serde_yaml::to_string(&*biz).unwrap();
+    println!("{}", serialized);
+}
+
+fn test_boz_using_mutible_self() {
+    println!("\nRunning Boz mutible self demo...");
+
+    let mut boz = Boz::default();
+    boz.increment_once();
+    boz.increment_twice();
+
+    // Print the results!
+    println!("Done! Here are the metrics:");
+    let serialized = serde_yaml::to_string(&boz).unwrap();
     println!("{}", serialized);
 }
 
 fn main() {
     simple_api_demo();
 
-    test_biz();
+    test_boz_using_mutible_self();
+
+    test_biz_throughput();
 
     let baz = Baz::default();
-
     sync_procmacro_demo(&baz);
 }

--- a/metered-macro/src/metered.rs
+++ b/metered-macro/src/metered.rs
@@ -38,6 +38,7 @@ pub fn metered(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenStream
         #code
 
         #[derive(Debug, Default, serde::Serialize)]
+        #[allow(missing_docs)]
         #visibility struct #registry_ident {
             #reg_fields
         }
@@ -70,6 +71,7 @@ pub fn metered(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenStream
             #code
 
             #[derive(Debug, Default, serde::Serialize)]
+            #[allow(missing_docs)]
             #visibility struct #fun_registry_ident {
                 #fun_reg_fields
             }

--- a/metered-macro/src/metered.rs
+++ b/metered-macro/src/metered.rs
@@ -114,13 +114,13 @@ impl Weave for MeteredWeave {
             let await_fut = syn::parse_str::<syn::Expr>("fut.await")?;
             quote! {
                 {
-                    let fut = async #block;
+                    let fut = (move || async move #block)();
                     #await_fut
                 }
             }
         } else {
             quote! {
-                #block
+                (move || #block)()
             }
         };
 

--- a/metered-macro/src/metered.rs
+++ b/metered-macro/src/metered.rs
@@ -152,27 +152,9 @@ fn measure_list(
         for metric in metric_requests.iter() {
             let metric_var = metric.ident();
             inner = quote! {
-                metered::measure! { #metric_var, #inner }
+                metered::measure! { &#registry_expr.#fun_ident.#metric_var, #inner }
             };
         }
-    }
-
-    // Let-bindings to avoid moving issues
-    for measure_req_attr in measure_request_attrs.iter() {
-        let metric_requests = measure_req_attr.to_requests();
-
-        for metric in metric_requests.iter() {
-            let metric_var = syn::Ident::new(&metric.field_name, proc_macro2::Span::call_site());
-
-            inner = quote! {
-                let #metric_var = &#registry_expr.#fun_ident.#metric_var;
-                #inner
-            };
-        }
-
-        // // Use debug routine if enabled!
-        // if let Some(opt) = metric.debug {
-        // }
     }
 
     // Add final braces

--- a/metered-macro/src/metered.rs
+++ b/metered-macro/src/metered.rs
@@ -114,13 +114,13 @@ impl Weave for MeteredWeave {
             let await_fut = syn::parse_str::<syn::Expr>("fut.await")?;
             quote! {
                 {
-                    let fut = (move || async move #block)();
+                    let fut = async #block;
                     #await_fut
                 }
             }
         } else {
             quote! {
-                (move || #block)()
+                #block
             }
         };
 

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -106,11 +106,10 @@ pub use aspect::Enter;
 /// It applies the metric and the expression is returned unchanged.
 #[macro_export]
 macro_rules! measure {
-    ($metric:ident, $e:expr) => {{
-        let _metric = $metric;
-        let _enter = $crate::Enter::enter(_metric);
+    ($metric:expr, $e:expr) => {{
+        let _enter = $crate::Enter::enter($metric);
         let _result = $e;
-        $crate::metric::on_result(_metric, _enter, &_result);
+        $crate::metric::on_result($metric, _enter, &_result);
         _result
     }};
 }

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -39,10 +39,10 @@
 //! #[metered::metered(registry = BizMetrics)]
 //! impl Biz {
 //!     #[measure([HitCount, Throughput])]
-//!     pub fn biz(&self) {        
+//!     pub fn biz(&self) {
 //!         let delay = std::time::Duration::from_millis(rand::random::<u64>() % 200);
 //!         std::thread::sleep(delay);
-//!     }   
+//!     }
 //! }
 //!
 //! # fn main() {
@@ -105,9 +105,10 @@ pub use aspect::Enter;
 #[macro_export]
 macro_rules! measure {
     ($metric:expr, $e:expr) => {{
-        let _enter = $crate::Enter::enter($metric);
+        let _metric_ptr = $metric as *const _;
+        let _enter = unsafe { $crate::Enter::enter(&(*_metric_ptr)) };
         let _result = $e;
-        $crate::metric::on_result($metric, _enter, &_result);
+        unsafe { $crate::metric::on_result(&(*_metric_ptr), _enter, &_result); }
         _result
     }};
 }

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -106,7 +106,7 @@ pub use aspect::Enter;
 macro_rules! measure {
     ($metric:expr, $e:expr) => {{
         let _metric_ptr = $metric as *const _;
-        let _enter = unsafe { $crate::Enter::enter(&(*_metric_ptr)) };
+        let _enter = unsafe { $crate::Enter::enter($metric) };
         let _result = $e;
         unsafe { $crate::metric::on_result(&(*_metric_ptr), _enter, &_result); }
         _result


### PR DESCRIPTION
Allow `measure!` to take an expression means we can create references to the metric container _as needed_ in the expansion. Therefore, it is no longer needed to store the reference across the scope of the expression being tested, so the expression is free to create and use `&mut self` as needed.