### PR TITLE
Add support for serde_prometheus

### DIFF
--- a/metered/src/hdr_histogram.rs
+++ b/metered/src/hdr_histogram.rs
@@ -89,22 +89,54 @@ impl Serialize for HdrHistogram {
         S: Serializer,
     {
         let hdr = &self.histo;
-        let ile = |v| hdr.value_at_percentile(v);
+
+        /// A percentile of this histogram - for supporting serialisers this will
+        /// ignore the key (such as `90%ile`) and instead add a dimension to the
+        /// metrics (such as `quantile=0.9`).
+        macro_rules! ile {
+            ($e:expr) => {
+                &MetricAlias(concat!("!|quantile=", $e), hdr.value_at_quantile($e))
+            }
+        }
+
+        /// A 'qualified' metric name - for supporting serialisers this will prepend
+        /// the metric name to this key, outputting `response_time_count`, for example
+        /// rather than just `count`.
+        macro_rules! qual {
+            ($e:expr) => {
+                &MetricAlias("<|", $e)
+            }
+        }
+
         use serde::ser::SerializeMap;
 
         let mut tup = serializer.serialize_map(Some(10))?;
-
-        tup.serialize_entry("samples", &hdr.len())?;
-        tup.serialize_entry("min", &hdr.min())?;
-        tup.serialize_entry("max", &hdr.max())?;
-        tup.serialize_entry("mean", &hdr.mean())?;
-        tup.serialize_entry("stdev", &hdr.stdev())?;
-        tup.serialize_entry("90%ile", &ile(90.0))?;
-        tup.serialize_entry("95%ile", &ile(95.0))?;
-        tup.serialize_entry("99%ile", &ile(99.0))?;
-        tup.serialize_entry("99.9%ile", &ile(99.9))?;
-        tup.serialize_entry("99.99%ile", &ile(99.99))?;
+        tup.serialize_entry("samples", qual!(hdr.len()))?;
+        tup.serialize_entry("min", qual!(hdr.min()))?;
+        tup.serialize_entry("max", qual!(hdr.max()))?;
+        tup.serialize_entry("mean", qual!(hdr.mean()))?;
+        tup.serialize_entry("stdev", qual!(hdr.stdev()))?;
+        tup.serialize_entry("90%ile", ile!(0.9))?;
+        tup.serialize_entry("95%ile", ile!(0.95))?;
+        tup.serialize_entry("99%ile", ile!(0.99))?;
+        tup.serialize_entry("99.9%ile", ile!(0.999))?;
+        tup.serialize_entry("99.99%ile", ile!(0.9999))?;
         tup.end()
+    }
+}
+
+/// This is a mocked 'newtype' (eg. `A(u64)`) that instead allows us to
+/// define our own type name that doesn't have to abide by Rust's constraints
+/// on type names. This allows us to do some manipulation of our metrics,
+/// allowing us to add dimensionality to our metrics via key=value pairs, or
+/// key manipulation on serialisers that support it.
+struct MetricAlias<T: Serialize>(&'static str, T);
+impl<T: Serialize> Serialize for MetricAlias<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_newtype_struct(self.0, &self.1)
     }
 }
 


### PR DESCRIPTION
This adds support for my [serde_prometheus](https://github.com/w4/serde_prometheus) crate.

In this crate the usually unused fields in the `serialize_newtype_*` methods are (ab)used to add metadata to fields we pass through, while still maintaining backwards compatibility with crates like `serde_json`.

```
> serde_prometheus::to_string(metrics, None, None)
response_time_samples{path = "baz/bazle"} 0
response_time_min{path = "baz/bazle"} 0
response_time_max{path = "baz/bazle"} 0
response_time_mean{path = "baz/bazle"} 0
response_time_stdev{path = "baz/bazle"} 0
response_time{quantile = "0.9", path = "baz/bazle"} 0
response_time{quantile = "0.95", path = "baz/bazle"} 0
response_time{quantile = "0.99", path = "baz/bazle"} 0
response_time{quantile = "0.999", path = "baz/bazle"} 0
response_time{quantile = "0.9999", path = "baz/bazle"} 0

> serde_json::to_string(metrics)
{
    "baz": {
        "bazle": {
            "response_time": {
                  "samples": 0,
                  "min": 0,
                  "max": 0,
                  "mean": 0,
                  "stdev": 0,
                  "90%ile": 0,
                  "95%ile": 0,
                  "99%ile": 0,
                  "99.9%ile": 0,
                  "99.99%ile": 0
            }
        }
    }
}
```