### PR TITLE
Make `AtomicTxPerSec` and `TxPerSec` visible by reexporting

### DIFF
--- a/metered/src/common/mod.rs
+++ b/metered/src/common/mod.rs
@@ -11,6 +11,5 @@ pub use hit_count::HitCount;
 pub use in_flight::InFlight;
 pub use response_time::ResponseTime;
 pub use throughput::Throughput;
-
 pub use throughput::AtomicTxPerSec;
 pub use throughput::TxPerSec;

--- a/metered/src/common/mod.rs
+++ b/metered/src/common/mod.rs
@@ -11,3 +11,6 @@ pub use hit_count::HitCount;
 pub use in_flight::InFlight;
 pub use response_time::ResponseTime;
 pub use throughput::Throughput;
+
+pub use throughput::AtomicTxPerSec;
+pub use throughput::TxPerSec;

--- a/metered/src/common/throughput/atomic_tps.rs
+++ b/metered/src/common/throughput/atomic_tps.rs
@@ -5,6 +5,7 @@ use crate::time_source::{Instant, StdInstant};
 use parking_lot::Mutex;
 use serde::{Serialize, Serializer};
 
+/// Threat-safe implementation of `RecordThroughput`. It uses a `Mutex` to wrap `TxPerSec`.
 pub struct AtomicTxPerSec<T: Instant = StdInstant> {
     inner: Mutex<TxPerSec<T>>,
 }

--- a/metered/src/common/throughput/atomic_tps.rs
+++ b/metered/src/common/throughput/atomic_tps.rs
@@ -5,7 +5,7 @@ use crate::time_source::{Instant, StdInstant};
 use parking_lot::Mutex;
 use serde::{Serialize, Serializer};
 
-/// Threat-safe implementation of `RecordThroughput`. It uses a `Mutex` to wrap `TxPerSec`.
+/// Thread-safe implementation of `RecordThroughput`. It uses a `Mutex` to wrap `TxPerSec`.
 pub struct AtomicTxPerSec<T: Instant = StdInstant> {
     inner: Mutex<TxPerSec<T>>,
 }

--- a/metered/src/common/throughput/tx_per_sec.rs
+++ b/metered/src/common/throughput/tx_per_sec.rs
@@ -1,11 +1,11 @@
 use super::RecordThroughput;
 use crate::hdr_histogram::HdrHistogram;
 use crate::clear::Clear;
-use crate::time_source::Instant;
+use crate::time_source::{Instant, StdInstant};
 use serde::{Serialize, Serializer};
 
 /// Non-thread safe implementation of `RecordThroughput`. Use as `RefCell<TxPerSec<T>>`.
-pub struct TxPerSec<T: Instant> {
+pub struct TxPerSec<T: Instant = StdInstant> {
     hdr_histogram: HdrHistogram,
     last: Option<T>,
     count: u64,

--- a/metered/src/common/throughput/tx_per_sec.rs
+++ b/metered/src/common/throughput/tx_per_sec.rs
@@ -1,8 +1,10 @@
 use super::RecordThroughput;
 use crate::hdr_histogram::HdrHistogram;
+use crate::clear::Clear;
 use crate::time_source::Instant;
 use serde::{Serialize, Serializer};
 
+/// Non-thread safe implementation of `RecordThroughput`. Use as `RefCell<TxPerSec<T>>`.
 pub struct TxPerSec<T: Instant> {
     hdr_histogram: HdrHistogram,
     last: Option<T>,
@@ -30,8 +32,14 @@ impl<T: Instant> RecordThroughput for std::cell::RefCell<TxPerSec<T>> {
     }
 }
 
+impl<T: Instant> Clear for std::cell::RefCell<TxPerSec<T>> {
+    fn clear(&self) {
+        self.borrow_mut().clear();
+    }
+}
+
 impl<T: Instant> TxPerSec<T> {
-    pub fn on_result(&mut self) {
+    pub(crate) fn on_result(&mut self) {
         // Record previous count if the 1-sec window has closed
         if let Some(ref last) = self.last {
             let elapsed_millis = last.elapsed_millis();
@@ -48,7 +56,7 @@ impl<T: Instant> TxPerSec<T> {
         self.count += 1;
     }
 
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.hdr_histogram.clear();
         self.last = None;
         self.count = 0;


### PR DESCRIPTION
Closes #16.