### PR TITLE
Introduce an `Instant` with microsecond precision

### DIFF
--- a/metered/src/common/response_time.rs
+++ b/metered/src/common/response_time.rs
@@ -39,7 +39,7 @@ impl<H: Histogram, T: Instant> Enter for ResponseTime<H, T> {
 
 impl<H: Histogram, T: Instant, R> OnResult<R> for ResponseTime<H, T> {
     fn on_result(&self, enter: T, _: &R) -> Advice {
-        let elapsed = enter.elapsed_millis();
+        let elapsed = enter.elapsed_time();
         self.0.record(elapsed);
         Advice::Return
     }

--- a/metered/src/common/throughput/tx_per_sec.rs
+++ b/metered/src/common/throughput/tx_per_sec.rs
@@ -34,8 +34,8 @@ impl<T: Instant> TxPerSec<T> {
     pub fn on_result(&mut self) {
         // Record previous count if the 1-sec window has closed
         if let Some(ref last) = self.last {
-            let elapsed_millis = last.elapsed_millis();
-            if elapsed_millis > 1000 {
+            let elapsed = last.elapsed_time();
+            if elapsed > T::ONE_SEC {
                 self.hdr_histogram.record(self.count);
                 self.count = 0;
                 self.last = Some(T::now());

--- a/metered/src/time_source.rs
+++ b/metered/src/time_source.rs
@@ -8,20 +8,44 @@ pub trait Instant {
     fn now() -> Self;
 
     /// Returns the elapsed time in milliseconds since an Instant was created.
-    fn elapsed_millis(&self) -> u64;
+    fn elapsed_time(&self) -> u64;
+
+    /// One second in the instant units.
+    const ONE_SEC: u64;
 }
 
-/// A new-type wrapper for std Instants and Metered's [Instant](trait.Instant.html) trait.
+/// A new-type wrapper for std Instants and Metered's [Instant](trait.Instant.html) trait that
+/// measures time in milliseconds.
 #[derive(Debug, Clone)]
 pub struct StdInstant(std::time::Instant);
 impl Instant for StdInstant {
+    const ONE_SEC: u64 = 1_000;
+
     fn now() -> Self {
         StdInstant(std::time::Instant::now())
     }
 
-    fn elapsed_millis(&self) -> u64 {
+    fn elapsed_time(&self) -> u64 {
         let elapsed = self.0.elapsed();
 
-        elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis())
+        elapsed.as_secs() * Self::ONE_SEC + u64::from(elapsed.subsec_millis())
+    }
+}
+
+/// A new-type wrapper for std Instants and Metered's [Instant](trait.Instant.html) trait that
+/// measures time in microseconds.
+#[derive(Debug, Clone)]
+pub struct StdInstantMicros(std::time::Instant);
+impl Instant for StdInstantMicros {
+    const ONE_SEC: u64 = 1_000_000;
+
+    fn now() -> Self {
+        StdInstantMicros(std::time::Instant::now())
+    }
+
+    fn elapsed_time(&self) -> u64 {
+        let elapsed = self.0.elapsed();
+
+        elapsed.as_secs() * Self::ONE_SEC + u64::from(elapsed.subsec_micros())
     }
 }

--- a/metered/src/time_source.rs
+++ b/metered/src/time_source.rs
@@ -7,7 +7,9 @@ pub trait Instant {
     /// Creates a new Instant representing the current time.
     fn now() -> Self;
 
-    /// Returns the elapsed time in milliseconds since an Instant was created.
+    /// Returns the elapsed time since an Instant was created.
+    ///
+    /// The unit depends on the Instant's resolution, as defined by the `ONE_SEC` constant.
     fn elapsed_time(&self) -> u64;
 
     /// One second in the instant units.


### PR DESCRIPTION
Requies an API breaking change. `Instant.elapsed_millis` is renamed to `elapsed_time`, and a new associated constant, `ONE_SEC` is introduced to specify one second in the instant units.

Closes #10.