### PR TITLE
Add support for nested error variants in the error_count macro

### DIFF
--- a/demos/src/baz.rs
+++ b/demos/src/baz.rs
@@ -3,13 +3,22 @@
 use metered::{metered, ErrorCount, HitCount, InFlight, ResponseTime};
 use thiserror::Error;
 
-#[metered::error_count(name = BazErrorCount)]
+#[metered::error_count(name = LibErrorCount, visibility = pub)]
 #[derive(Debug, Error)]
-pub enum BazError {
+pub enum LibError {
     #[error("I failed!")]
     Failure,
     #[error("Bad input")]
     BadInput,
+}
+
+#[metered::error_count(name = BazErrorCount, visibility = pub)]
+#[derive(Debug, Error)]
+pub enum BazError {
+    #[error("lib error: {0}")]
+    Lib(#[from] #[nested] LibError),
+    #[error("io error")]
+    Io,
 }
 
 #[derive(Default, Debug, serde::Serialize)]
@@ -86,7 +95,7 @@ impl Baz {
             println!("bazle !");
             Ok(())
         } else {
-            Err(BazError::Failure)
+            Err(LibError::Failure.into())
         }
     }
 

--- a/metered-macro/src/error_count.rs
+++ b/metered-macro/src/error_count.rs
@@ -1,7 +1,7 @@
 use crate::error_count_opts::ErrorCountKeyValAttribute;
 use heck::SnakeCase;
 use proc_macro::TokenStream;
-use syn::{Ident, ItemEnum};
+use syn::{Attribute, Field, Fields, Ident, ItemEnum};
 
 pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
     let attrs: ErrorCountKeyValAttribute = syn::parse(attrs)?;
@@ -9,7 +9,28 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
     let vis = attrs.visibility;
     let metrics_ident = attrs.name_ident;
 
-    let input: ItemEnum = syn::parse(item)?;
+    let mut input: ItemEnum = syn::parse(item)?;
+
+    let nested_attrs = get_nested_attrs(&mut input)?;
+
+    // get the type of the metric for each variant, most of the time this will be `C`, but
+    // if `#[nested(Abc)]` is on a variant field, the type will instead be set to `Abc` and
+    // incrs will be delegated there
+    let metric_type = nested_attrs
+        .iter()
+        .map(|(_, v)| {
+            if let Some((field, attr)) = v {
+                let error_type = &field.ty;
+                attr.parse_args::<proc_macro2::TokenStream>()
+                    .unwrap_or_else(
+                        |_| quote!(<#error_type as metered::ErrorBreakdown<C>>::ErrorCount),
+                    )
+            } else {
+                quote!(C)
+            }
+        })
+        .collect::<Vec<_>>();
+
     let ident = &input.ident;
 
     let variants = input.variants.iter().map(|v| &v.ident);
@@ -20,17 +41,60 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         .map(|v| Ident::new(&v.ident.to_string().to_snake_case(), v.ident.span()))
         .collect();
 
+    // copy #[cfg(..)] attributes from the variant and apply them to the corresponding
+    // error in our struct so we don't point to an invalid variant in certain configurations.
+    let cfg_attrs: Vec<Vec<&Attribute>> = input
+        .variants
+        .iter()
+        .map(|v| v.attrs.iter().filter(|v| v.path.is_ident("cfg")).collect())
+        .collect();
+
     // generate unbound arg params for each enum variant
-    let variants_args = input.variants.iter().map(|v| match &v.fields {
-        syn::Fields::Named(_) => quote!({ .. }),
-        syn::Fields::Unnamed(v) => {
-            let args = v.unnamed.iter().map(|_| quote!(_));
-            quote! {
-                (#( #args, )*)
+    let variants_args = nested_attrs
+        .iter()
+        .map(|(fields, nested_attr)| match &fields {
+            syn::Fields::Named(_) => {
+                if let Some((field, _)) = nested_attr {
+                    let key = field.ident.as_ref().expect("field missing ident");
+                    quote!({ #key, .. })
+                } else {
+                    quote!({ .. })
+                }
             }
-        }
-        syn::Fields::Unit => quote!(),
-    });
+            syn::Fields::Unnamed(_) => {
+                let args = fields.iter().map(|field| {
+                    if field.attrs.iter().any(|attr| attr.path.is_ident("nested")) {
+                        quote!(nested)
+                    } else {
+                        quote!(_)
+                    }
+                });
+                quote! {
+                    (#( #args, )*)
+                }
+            }
+            syn::Fields::Unit => quote!(),
+        });
+
+    // generate incr calls for each variant, if a field is marked with `#[nested]`, the incr is instead
+    // delegated there
+    let variant_incr_call =
+        nested_attrs
+            .iter()
+            .zip(snake_variants.iter())
+            .map(|((_, nested_attr), ident)| {
+                if let Some((field, attr)) = nested_attr {
+                    let inner_val_ident = field
+                        .ident
+                        .clone()
+                        .unwrap_or_else(|| Ident::new("nested", attr.bracket_token.span));
+                    quote! {{
+                        self.#ident.incr(#inner_val_ident);
+                    }}
+                } else {
+                    quote!(self.#ident.incr())
+                }
+            });
 
     Ok(quote! {
         #input
@@ -38,15 +102,26 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         #[derive(serde::Serialize, Default, Debug)]
         #[allow(missing_docs)]
         #vis struct #metrics_ident<C: metered::metric::Counter = metered::atomic::AtomicInt<u64>> {
+            #[serde(skip)]
+            __phantom: std::marker::PhantomData<C>,
             #(
+                #(#cfg_attrs)*
                 #[serde(rename = #stringified_variants, serialize_with = "metered::error_variant_serializer")]
-                pub #snake_variants: C,
+                pub #snake_variants: #metric_type,
             )*
+        }
+
+        impl<C: metered::metric::Counter> #metrics_ident<C> {
+            pub fn incr(&self, err: &#ident) {
+                match err {
+                    #( #(#cfg_attrs)* #ident::#variants #variants_args => #variant_incr_call, )*
+                }
+            }
         }
 
         impl<C: metered::metric::Counter> metered::clear::Clear for #metrics_ident<C> {
             fn clear(&self) {
-                #( self.#snake_variants.clear(); )*
+                #( #(#cfg_attrs)* self.#snake_variants.clear(); )*
             }
         }
 
@@ -60,12 +135,63 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         impl<T, C: metered::metric::Counter> metered::metric::OnResult<Result<T, #ident>> for #metrics_ident<C> {
             fn on_result(&self, _: (), r: &Result<T, #ident>) -> metered::metric::Advice {
                 if let Err(e) = r {
-                    match e {
-                        #( #ident::#variants #variants_args => self.#snake_variants.incr(), )*
-                    }
+                    self.incr(e);
                 }
                 metered::metric::Advice::Return
             }
         }
+
+        impl<C: metered::metric::Counter> metered::ErrorBreakdown<C> for #ident {
+            type ErrorCount = #metrics_ident<C>;
+        }
     }.into())
+}
+
+type FieldWithNestedAttribute = Option<(Field, Attribute)>;
+
+/// Gets all variants from the given `ItemEnum`, and returns `Some(Field, Attribute)` along with
+/// each variant if one of fields contained a `#[nested]` attribute.
+///
+/// If a `#[nested]` attribute is found, then the attribute itself removed from `input` so that
+/// we don't get "unrecognised attribute" errors.
+fn get_nested_attrs(input: &mut ItemEnum) -> syn::Result<Vec<(Fields, FieldWithNestedAttribute)>> {
+    let attrs = input
+        .variants
+        .iter_mut()
+        .map(|v| {
+            // clone fields before we do any mutation on it so consumers can figure out the position
+            // of #[nested] fields.
+            let fields = v.fields.clone();
+
+            let inner_fields = match &mut v.fields {
+                syn::Fields::Named(v) => &mut v.named,
+                syn::Fields::Unnamed(v) => &mut v.unnamed,
+                _ => return Ok((fields, None)),
+            };
+
+            // field containing the nested attribute, along with the attribute itself
+            let mut nested_attr = None;
+
+            for field in inner_fields {
+                if let Some(pos) = field.attrs.iter().position(|a| a.path.is_ident("nested")) {
+                    let attr = field.attrs.remove(pos);
+
+                    // if we've already found a nested attribute on a field in the current variant,
+                    // throw an error
+                    if nested_attr.is_some() {
+                        return Err(syn::Error::new(
+                            attr.bracket_token.span,
+                            "Can't declare `#[nested]` on more than one field in a single variant",
+                        ));
+                    }
+
+                    nested_attr = Some((field.clone(), attr.clone()));
+                }
+            }
+
+            Ok((fields, nested_attr))
+        })
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    Ok(attrs)
 }

--- a/metered-macro/src/lib.rs
+++ b/metered-macro/src/lib.rs
@@ -96,13 +96,20 @@ pub fn metered(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// # use metered_macro::{metered, error_count};
 /// # use thiserror::Error;
 /// #
-/// #[error_count(name = ErrorCount, visibility = pub)]
+/// #[error_count(name = LibErrorCount, visibility = pub)]
 /// #[derive(Debug, Error)]
-/// pub enum Error {
+/// pub enum LibError {
 /// #   #[error("read error")]
 ///     ReadError,
 /// #   #[error("init error")]
 ///     InitError,
+/// }
+///
+/// #[error_count(name = ErrorCount, visibility = pub)]
+/// #[derive(Debug, Error)]
+/// pub enum Error {
+/// #   #[error("error from lib: {0}")]
+///     MyLibrary(#[from] #[nested] LibError),
 /// }
 ///
 /// #[derive(Default, Debug)]
@@ -114,14 +121,14 @@ pub fn metered(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// impl Baz {
 ///     #[measure(ErrorCount)]
 ///     pub fn biz(&self) -> Result<(), Error> {        
-///         Err(Error::InitError)
+///         Err(LibError::InitError.into())
 ///     }   
 /// }
 ///
 /// let baz = Baz::default();
 /// baz.biz();
-/// assert_eq!(baz.metrics.biz.error_count.read_error.get(), 0);
-/// assert_eq!(baz.metrics.biz.error_count.init_error.get(), 1);
+/// assert_eq!(baz.metrics.biz.error_count.my_library.read_error.get(), 0);
+/// assert_eq!(baz.metrics.biz.error_count.my_library.init_error.get(), 1);
 /// ```
 ///
 /// - `name` is required and must be a valid Rust ident, this is the name

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -177,5 +177,12 @@ pub fn error_variant_serializer<S: serde::Serializer, T: serde::Serialize>(
     value: &T,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serializer.serialize_newtype_struct("!|variant==<", value)
+    serializer.serialize_newtype_struct("!|variant[::]==<", value)
+}
+
+/// Trait applied to error enums by `#[metered::error_count]` to identify generated error
+/// count structs.
+pub trait ErrorBreakdown<C: metric::Counter> {
+    /// The generated error count struct.
+    type ErrorCount;
 }


### PR DESCRIPTION
Combined with https://github.com/w4/serde_prometheus/commit/2dfba96a749e70349423a279a0645217fd840536 this allows for adding a `#[nested(MyOtherGeneratedErrorCount)]` attribute to a single field in a variant to allow for nested error counts, when serializing the resulting metrics struct with serde you'll end up with variants such as (from the `demos/` folder):

```
baz_error_count{variant = "Lib::Failure", path = "metric_reg/bazle"} 1
baz_error_count{variant = "Lib::BadInput", path = "metric_reg/bazle"} 0
```