### PR TITLE
Update Metrics via an OnResultMut rather than an OnResult

### DIFF
--- a/metered/Cargo.toml
+++ b/metered/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 metered-macro = { version = "0.7.0", path = "../metered-macro" }
-aspect = "0.2.1"
+aspect = "0.3"
 hdrhistogram = "7.1"
 atomic = "0.5"
 parking_lot = "0.11"

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -165,8 +165,8 @@ macro_rules! measure {
     ($metric:expr, $e:expr) => {{
         let metric = $metric;
         let guard = $crate::metric::ExitGuard::new(metric);
-        let result = $e;
-        guard.on_result(&result);
+        let mut result = $e;
+        guard.on_result(&mut result);
         result
     }};
 }


### PR DESCRIPTION
Draft waiting on magnet/aspect-rs#3 

Unlike the `aspect-rs` change, this is not a breaking change for consumers of `metered`. This will allow consumers to optionally take a mut ref to the return result, which is useful for ie. inspecting streams to increment metrics:

```rust
impl<'a, T: 'a> OnResultMut<Pin<Box<dyn futures::Stream<Item = Result<T>> + 'a>>>
    for CountResultStream
{
    fn on_result(
        &self,
        _enter: <Self as Enter>::E,
        result: &mut Pin<Box<dyn futures::Stream<Item = Result<T>> + 'a>>,
    ) -> Advice {
        let successful = Arc::clone(&self.successful);
        let errors = Arc::clone(&self.errors);

        take_mut::take(result, move |stream| {
            Box::pin(stream.inspect(move |v| {
                if let Err(e) = v {
                    errors.incr(e);
                } else {
                    successful.incr();
                }
            }))
        });

        Advice::Return
    }
}
```

Using `OnResultMut` is optional, and `OnResult` can be used instead as the aspect-rs change will automatically provide an `OnResultMut` implementation for any implementors of `OnResult`.