### PR TITLE
Add blanket implementations for Clear

### DIFF
--- a/metered/src/clear.rs
+++ b/metered/src/clear.rs
@@ -1,6 +1,8 @@
 //! A module providing a Clear trait which signals metrics to clear their state
 //! if applicable.
 
+use std::sync::Arc;
+
 /// The `Clear` trait is used to signal metrics to clear their state if
 /// applicable
 ///
@@ -11,6 +13,18 @@
 pub trait Clear {
     /// Requests to clear self.
     fn clear(&self);
+}
+
+impl<T: Clear> Clear for Arc<T> {
+    fn clear(&self) {
+        (&**self).clear();
+    }
+}
+
+impl<T: Clear> Clear for &T {
+    fn clear(&self) {
+        (*self).clear();
+    }
 }
 
 /// The `Clearable` trait is used to provide metadata around some types that can


### PR DESCRIPTION
This will allow to run `Clear::clear` on types implementing `Clear` but that are wrapped in an `Arc` or are borrowed. This is specially useful when generating the code from macros. Example:

```rust
struct ServiceMetrics {
    response_time: Arc<metered::ResponseTime>,
}

impl ServiceMetrics {
    fn clear_histograms(&self) {
        metered::clear::Clear::clear(&self.response_time);
    }
}
```