### PR TITLE
Wrapping metrics + multiple increment/decrement caps for int-based metrics

### DIFF
--- a/demos/src/main.rs
+++ b/demos/src/main.rs
@@ -27,6 +27,12 @@ fn test(should_fail: bool, metrics: &TestMetrics) -> Result<(), ()> {
     })
 }
 
+fn test_incr(metrics: &TestMetrics) -> Result<(), ()> {
+    let hit_count = &metrics.hit_count;
+    hit_count.incr_by(3);
+    Ok(())
+}
+
 fn sync_procmacro_demo(baz: &Baz) {
     for i in 1..=10 {
         baz.foo();
@@ -50,6 +56,8 @@ fn simple_api_demo() {
 
     let _ = test(false, &metrics);
     let _ = test(true, &metrics);
+    let _ = test_incr(&metrics);
+
     // Print the results!
     let serialized = serde_prometheus::to_string(&metrics, None, HashMap::new()).unwrap();
     println!("{}", serialized);

--- a/metered/Cargo.toml
+++ b/metered/Cargo.toml
@@ -15,13 +15,15 @@ edition = "2018"
 [dependencies]
 metered-macro = { version = "0.8.0", path = "../metered-macro" }
 aspect = "0.3"
-hdrhistogram = "7.1"
+hdrhistogram = "7.5"
 atomic = "0.5"
-parking_lot = "0.11"
+parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 rand = "0.8"
+proptest = "1.0"
 
 [features]
 # no features by default

--- a/metered/src/int_counter.rs
+++ b/metered/src/int_counter.rs
@@ -5,14 +5,16 @@ use crate::{
     atomic::AtomicInt,
     clear::{Clear, Clearable},
     metric::Counter,
+    num_wrapper::NumWrapper,
 };
 use std::cell::Cell;
 
 macro_rules! impl_counter_for {
     ($int:path) => {
         impl Counter for Cell<$int> {
-            fn incr(&self) {
-                self.set(self.get() + 1);
+            fn incr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                self.set(self.get().wrapping_add(v));
             }
         }
 
@@ -29,8 +31,9 @@ macro_rules! impl_counter_for {
         }
 
         impl Counter for AtomicInt<$int> {
-            fn incr(&self) {
-                AtomicInt::<$int>::incr(&self);
+            fn incr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                AtomicInt::<$int>::incr_by(&self, v);
             }
         }
 

--- a/metered/src/int_gauge.rs
+++ b/metered/src/int_gauge.rs
@@ -1,28 +1,32 @@
 //! A module providing thread-safe and unsynchronized implementations for Gauges
 //! on various unsized integers.
 
-use crate::{atomic::AtomicInt, metric::Gauge};
+use crate::{atomic::AtomicInt, metric::Gauge, num_wrapper::NumWrapper};
 use std::cell::Cell;
 
 macro_rules! impl_gauge_for {
     ($int:path) => {
         impl Gauge for Cell<$int> {
-            fn incr(&self) {
-                self.set(self.get() + 1);
+            fn incr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                self.set(self.get().wrapping_add(v));
             }
 
-            fn decr(&self) {
-                self.set(self.get() - 1);
+            fn decr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                self.set(self.get().wrapping_sub(v));
             }
         }
 
         impl Gauge for AtomicInt<$int> {
-            fn incr(&self) {
-                AtomicInt::<$int>::incr(&self);
+            fn incr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                AtomicInt::<$int>::incr_by(&self, v);
             }
 
-            fn decr(&self) {
-                AtomicInt::<$int>::decr(&self);
+            fn decr_by(&self, count: usize) {
+                let v = NumWrapper::<$int>::wrap(count);
+                AtomicInt::<$int>::decr_by(&self, v);
             }
         }
     };

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -148,6 +148,7 @@ pub mod hdr_histogram;
 pub mod int_counter;
 pub mod int_gauge;
 pub mod metric;
+pub(crate) mod num_wrapper;
 pub mod time_source;
 
 pub use common::{ErrorCount, HitCount, InFlight, ResponseTime, Throughput};

--- a/metered/src/metric.rs
+++ b/metered/src/metric.rs
@@ -2,7 +2,7 @@
 
 use crate::clear::{Clear, Clearable};
 /// Re-export `aspect-rs`'s types to avoid crates depending on it.
-pub use aspect::{Advice, OnResult, OnResultMut, Enter};
+pub use aspect::{Advice, Enter, OnResult, OnResultMut};
 use serde::Serialize;
 use std::marker::PhantomData;
 
@@ -60,16 +60,40 @@ impl<'a, R, M: Metric<R>> Drop for ExitGuard<'a, R, M> {
 /// A trait for Counters
 pub trait Counter: Default + Clear + Clearable + Serialize {
     /// Increment the counter
-    fn incr(&self);
+    fn incr(&self) {
+        self.incr_by(1)
+    }
+
+    /// Increment the counter by count in one step
+    ///
+    /// Supplying a count larger than the underlying counter's remaining capacity
+    /// will wrap like [`u8::wrapping_add`] and similar methods.
+    fn incr_by(&self, count: usize);
 }
 
 /// A trait for Gauges
 pub trait Gauge: Default + Clear + Serialize {
     /// Increment the counter
-    fn incr(&self);
+    fn incr(&self) {
+        self.incr_by(1)
+    }
 
     /// Decrement the counter
-    fn decr(&self);
+    fn decr(&self) {
+        self.decr_by(1)
+    }
+
+    /// Increment the gauge by count in one step
+    ///
+    /// Supplying a count larger than the underlying counter's remaining capacity
+    /// will wrap like [`u8::wrapping_add`] and similar methods.
+    fn incr_by(&self, count: usize);
+
+    /// Decrement the gauge by count in one step
+    ///
+    /// Supplying a count larger than the underlying counter's current value
+    /// will wrap like [`u8::wrapping_sub`] and similar methods.
+    fn decr_by(&self, count: usize);
 }
 
 /// A trait for Histograms

--- a/metered/src/num_wrapper.rs
+++ b/metered/src/num_wrapper.rs
@@ -1,0 +1,152 @@
+use std::marker::PhantomData;
+
+/// Metered metrics wrap when the counters are at capacity instead of
+/// overflowing or underflowing.
+///
+/// This struct provides wrapping logic where a metric can be incremented or
+/// decremented `N` times, where `N` is `usize`.
+///
+/// This is the most logical default:
+/// * It is observable
+/// * Metered should never panic business code
+/// * While we could argue that gauges saturate at max capacity, doing
+/// so will unbalance the gauge when decrementing the count after a saturated add.
+/// Instead we guarantee that for all `N`, each `incr_by(N)` followed by a `decr_by(N)`
+/// results in the original value.
+///
+/// Should we avoid calling `NumWrapper` with `count = 1`, i.e is the optimizer able
+/// to get rid of the wrapping computations?  The Godbolt compiler explorer shows that
+/// starting `opt-level = 1`, the generated call is equivalent.  Program below for
+/// future reference:
+/// ```rust
+/// pub fn wrap(count: usize) -> u8 {
+///     (count % (u8::MAX as usize + 1)) as u8
+/// }
+///
+/// pub fn naive(c: u8) -> u8 {
+///     c.wrapping_add(wrap(1))
+/// }
+///
+/// pub fn manual(c: u8) -> u8  {
+///     c.wrapping_add(1)
+/// }
+///
+///
+/// pub fn main(){
+///     let m = manual(42);
+///     let n = naive(42);
+///     println!("{n} {m}");
+/// }
+/// ```
+pub(crate) struct NumWrapper<T>(PhantomData<T>);
+
+macro_rules! impl_num_wrapper_for_smaller_than_usize {
+    ($int:path) => {
+        impl NumWrapper<$int> {
+            /// Wrap count wrapped over $int
+            pub(crate) fn wrap(count: usize) -> $int {
+                (count % (<$int>::MAX as usize + 1)) as $int
+            }
+        }
+    };
+}
+
+macro_rules! impl_num_wrapper_for_equal_or_larger_than_usize {
+    ($int:path) => {
+        impl NumWrapper<$int> {
+            /// Return count as $int
+            pub(crate) fn wrap(count: usize) -> $int {
+                count as $int
+            }
+        }
+    };
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_pointer_width = "8")] {
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u8);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u16);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u32);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u64);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u128);
+    } else if #[cfg(target_pointer_width = "16")] {
+        impl_num_wrapper_for_smaller_than_usize!(u8);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u16);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u32);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u64);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u128);
+    } else if #[cfg(target_pointer_width = "32")] {
+        impl_num_wrapper_for_smaller_than_usize!(u8);
+        impl_num_wrapper_for_smaller_than_usize!(u16);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u32);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u64);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u128);
+    } else if #[cfg(target_pointer_width = "64")] {
+        impl_num_wrapper_for_smaller_than_usize!(u8);
+        impl_num_wrapper_for_smaller_than_usize!(u16);
+        impl_num_wrapper_for_smaller_than_usize!(u32);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u64);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u128);
+    } else if #[cfg(target_pointer_width = "128")] {
+        impl_num_wrapper_for_smaller_than_usize!(u8);
+        impl_num_wrapper_for_smaller_than_usize!(u16);
+        impl_num_wrapper_for_smaller_than_usize!(u32);
+        impl_num_wrapper_for_smaller_than_usize!(u64);
+        impl_num_wrapper_for_equal_or_larger_than_usize!(u128);
+    } else {
+        compile_error!("Unsupported architecture - unhandled pointer size.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    // test with u8 for more wrapping - same model/properties applies to other ints.
+    fn incr_by(cc: u8, count: usize) -> u8 {
+        let v = NumWrapper::<u8>::wrap(count);
+        cc.wrapping_add(v)
+    }
+    fn incr_by_naive(mut cc: u8, count: usize) -> u8 {
+        for _ in 0..count {
+            cc = cc.wrapping_add(1);
+        }
+        cc
+    }
+
+    fn decr_by(cc: u8, count: usize) -> u8 {
+        let v = NumWrapper::<u8>::wrap(count);
+        cc.wrapping_sub(v)
+    }
+    fn decr_by_naive(mut cc: u8, count: usize) -> u8 {
+        for _ in 0..count {
+            cc = cc.wrapping_sub(1);
+        }
+        cc
+    }
+
+    proptest! {
+        #[test]
+        fn test_wrapping_incr(x: u8, y in 0..4096usize) {
+            // Tests if calling incr() Y times returns the same value
+            // as the optimized version
+            assert_eq!(incr_by_naive(x, y), incr_by(x, y));
+        }
+
+        #[test]
+        fn test_wrapping_decr(x: u8,  y in 0..4096usize) {
+            // Tests if calling decr() Y times returns the same value
+            // as the optimized version
+            assert_eq!(decr_by_naive(x, y), decr_by(x, y));
+        }
+
+        #[test]
+        fn test_wrapping_incr_decr_symmetric(x: u8, y: usize) {
+            // reduce strategy space, usize takes too long
+            // Tests if calling decr() Y times on incr() Y times returns
+            // the original value
+            assert_eq!(x, decr_by(incr_by(x, y), y));
+        }
+    }
+}


### PR DESCRIPTION
Reworked #36 based on previous suggested changes.

This PR also fixes the behavior of integer-based behavior - they would previously use `+` or `-` operators instead of `wrapping_add` and `wrapping_sub`, thus by default behaving differently between `debug` and `release` modes (and potentially panicking in non-default configurations).  I believe wrapping is the only sane behavior - even if it is obviously not desirable.  Wrapping also behaves like a redeployment (counter reset) or a call to `Clear`, most metrics platform like Grafana or Prometheus are able to deal with hit counts/request rates being reset.