### PR TITLE
Make TxPerSec accurately record intervals of 0 TPS

### DIFF
--- a/metered/src/hdr_histogram.rs
+++ b/metered/src/hdr_histogram.rs
@@ -86,6 +86,15 @@ impl HdrHistogram {
         self.histo.saturating_record(value);
     }
 
+    /// Records  multiple samples for a value to the histogram
+    ///
+    /// This is a saturating record: if the value is higher than `max_bound`,
+    /// max_bound will be recorded instead.
+    pub fn record_n(&mut self, value: u64, count: u64) {
+        // All recordings will be saturating
+        self.histo.saturating_record_n(value, count);
+    }
+
     /// Clears the values of the histogram
     pub fn clear(&mut self) {
         self.histo.reset();


### PR DESCRIPTION
At the moment TxPerSec ignores windows where nothing is recorded.

This means if `on_result` is called at T=0secs and then at T=10secs it will
- Set last to 0sec, count += 1
- Set last to 10secs, record the count as 1

Instead the count of 0 for time T=1 to T=9 should be recorded

This implements this

I diffed the demo for before and after to test:
https://gist.github.com/nhawkes/5bc2133e5509b7ec911f7257274198f6/revisions