### PR TITLE
Use a trait for ErrorBreakdown's incr function

### DIFF
--- a/metered-macro/src/error_count.rs
+++ b/metered-macro/src/error_count.rs
@@ -121,8 +121,8 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
             )*
         }
 
-        impl<C: metered::metric::Counter> #metrics_ident<C> {
-            pub fn incr(&self, err: &#ident) {
+        impl<C: metered::metric::Counter> metered::ErrorBreakdownIncr<#ident> for #metrics_ident<C> {
+            fn incr(&self, err: &#ident) {
                 match err {
                     #( #(#cfg_attrs)* #ident::#variants #variants_args => #variant_incr_call, )*
                 }
@@ -145,7 +145,7 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         impl<T, C: metered::metric::Counter> metered::metric::OnResult<Result<T, #ident>> for #metrics_ident<C> {
             fn on_result(&self, _: (), r: &Result<T, #ident>) -> metered::metric::Advice {
                 if let Err(e) = r {
-                    self.incr(e);
+                    metered::ErrorBreakdownIncr::incr(self, e);
                 }
                 metered::metric::Advice::Return
             }

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -205,3 +205,10 @@ pub trait ErrorBreakdown<C: metric::Counter> {
     /// The generated error count struct.
     type ErrorCount;
 }
+
+/// Generic trait for `ErrorBreakdown::ErrorCount` to increase error count for a
+/// specific variant by 1.
+pub trait ErrorBreakdownIncr<E> {
+    /// Increase count for given variant by 1.
+    fn incr(&self, e: &E);
+}


### PR DESCRIPTION
This allows consumers to be generic over generated `ErrorCount`s, allowing for implementation of wrapped errors enums containing additional metadata.

This is a breaking change since `incr` was previously apart of the generated `ErrorCount`'s public API.