### PR TITLE
Match over unit pattern in expanded macro to satisfy clippy 0.1.73

### DIFF
--- a/metered-macro/src/error_count.rs
+++ b/metered-macro/src/error_count.rs
@@ -143,7 +143,7 @@ pub fn error_count(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         }
 
         impl<T, C: metered::metric::Counter> metered::metric::OnResult<Result<T, #ident>> for #metrics_ident<C> {
-            fn on_result(&self, _: (), r: &Result<T, #ident>) -> metered::metric::Advice {
+            fn on_result(&self, (): (), r: &Result<T, #ident>) -> metered::metric::Advice {
                 if let Err(e) = r {
                     self.incr(e);
                 }


### PR DESCRIPTION
With Rust 1.73, the following code:
```rust
#![warn(clippy::pedantic)]

#[derive(Debug, thiserror::Error)]
#[metered::error_count(name = ErrorCount, visibility = pub)]
pub enum Error {
    #[error("msg")]
    Variant,
}
```
raises a clippy warning:
```
warning: matching over `()` is more explicit
 --> src/lib.rs:4:1
  |
4 | #[metered::error_count(name = ErrorCount, visibility = pub)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
note: the lint level is defined here
 --> src/lib.rs:1:9
  |
1 | #![warn(clippy::pedantic)]
  |         ^^^^^^^^^^^^^^^^
  = note: `#[warn(clippy::ignored_unit_patterns)]` implied by `#[warn(clippy::pedantic)]`
  = note: this warning originates in the attribute macro `metered::error_count` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR satisfies the clippy lint. Pattern tested with Rust 1.31.0.