### PR TITLE
Add NoneCount metric

### DIFF
--- a/metered/src/common/mod.rs
+++ b/metered/src/common/mod.rs
@@ -3,11 +3,13 @@
 mod error_count;
 mod hit_count;
 mod in_flight;
+mod none_count;
 mod response_time;
 mod throughput;
 
 pub use error_count::ErrorCount;
 pub use hit_count::HitCount;
 pub use in_flight::InFlight;
+pub use none_count::NoneCount;
 pub use response_time::ResponseTime;
 pub use throughput::{AtomicTxPerSec, RecordThroughput, Throughput, TxPerSec};

--- a/metered/src/common/none_count.rs
+++ b/metered/src/common/none_count.rs
@@ -1,0 +1,63 @@
+//! A module providing the `NoneCount` metric.
+
+use crate::{
+    atomic::AtomicInt,
+    clear::Clear,
+    metric::{Counter, Metric},
+};
+use aspect::{Advice, Enter, OnResult};
+use serde::Serialize;
+use std::ops::Deref;
+
+/// A metric counting how many times the return value is Ok(None) or None.
+///
+/// `SomeCount` is not provided since can be calculated by subtracting `NoneCount` from `HitCount`.
+///
+/// This is a light-weight metric.
+///
+/// By default, `NoneCount` uses a lock-free `u64` `Counter`, which makes sense
+/// in multithread scenarios. Non-threaded applications can gain performance by
+/// using a `std::cell:Cell<u64>` instead.
+#[derive(Clone, Default, Debug, Serialize)]
+pub struct NoneCount<C: Counter = AtomicInt<u64>>(pub C);
+
+impl<C: Counter, T, E> Metric<Result<Option<T>, E>> for NoneCount<C> {}
+
+impl<C: Counter, T> Metric<Option<T>> for NoneCount<C> {}
+
+impl<C: Counter> Enter for NoneCount<C> {
+    type E = ();
+    fn enter(&self) {}
+}
+
+impl<C: Counter, T, E> OnResult<Result<Option<T>, E>> for NoneCount<C> {
+    fn on_result(&self, _: (), r: &Result<Option<T>, E>) -> Advice {
+        if matches!(r, Ok(None)) {
+            self.0.incr();
+        }
+        Advice::Return
+    }
+}
+
+impl<C: Counter, T> OnResult<Option<T>> for NoneCount<C> {
+    fn on_result(&self, _: (), r: &Option<T>) -> Advice {
+        if r.is_none() {
+            self.0.incr();
+        }
+        Advice::Return
+    }
+}
+
+impl<C: Counter> Clear for NoneCount<C> {
+    fn clear(&self) {
+        self.0.clear();
+    }
+}
+
+impl<C: Counter> Deref for NoneCount<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
Adds a convenience metric for counting the number of `Ok(None)` or `None` values returned. Useful for things like caches/repositories where you might want to count the number of cache misses separate from errors.