### PR TITLE
Use OnResultOwned with metric

### DIFF
--- a/metered-macro/Cargo.toml
+++ b/metered-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metered-macro"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Simon Chemouil <simon.chemouil@lambdacube.fr>"]
 license = "Apache-2.0 OR MIT"
 readme = "../README.md"

--- a/metered/Cargo.toml
+++ b/metered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metered"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Simon Chemouil <simon.chemouil@lambdacube.fr>"]
 license = "Apache-2.0 OR MIT"
 readme = "../README.md"
@@ -13,8 +13,8 @@ categories = ["rust-patterns", "development-tools::profiling", "data-structures"
 edition = "2018"
 
 [dependencies]
-metered-macro = { version = "0.9.0", path = "../metered-macro" }
-aspect = "0.3"
+metered-macro = { version = "0.10.0", path = "../metered-macro" }
+aspect = "0.4"
 hdrhistogram = "7.5"
 atomic = "0.5"
 parking_lot = "0.12"

--- a/metered/src/lib.rs
+++ b/metered/src/lib.rs
@@ -202,9 +202,7 @@ macro_rules! measure {
     ($metric:expr, $e:expr) => {{
         let metric = $metric;
         let guard = $crate::metric::ExitGuard::new(metric);
-        let mut result = $e;
-        guard.on_result(&mut result);
-        result
+        guard.on_result($e)
     }};
 }
 

--- a/metered/src/metric.rs
+++ b/metered/src/metric.rs
@@ -2,7 +2,7 @@
 
 use crate::clear::{Clear, Clearable};
 /// Re-export `aspect-rs`'s types to avoid crates depending on it.
-pub use aspect::{Advice, Enter, OnResult, OnResultMut};
+pub use aspect::{Advice, Enter, OnResult, OnResultMut, OnResultOwned};
 use serde::Serialize;
 use std::marker::PhantomData;
 
@@ -12,12 +12,12 @@ use std::marker::PhantomData;
 ///
 /// The return type, R, of the expression can be captured to perform special
 /// handling.
-pub trait Metric<R>: Default + OnResultMut<R> + Clear + Serialize {}
+pub trait Metric<R>: Default + OnResultOwned<R> + Clear + Serialize {}
 
 // Needed to force `measure!` to work only with the [`Metric`] trait.
 #[doc(hidden)]
-pub fn on_result<R, A: Metric<R>>(metric: &A, _enter: <A as Enter>::E, _result: &mut R) -> Advice {
-    metric.on_result(_enter, _result)
+pub fn on_result<R, A: Metric<R>>(metric: &A, _enter: <A as Enter>::E, result: R) -> (Advice, R) {
+    metric.on_result(_enter, result)
 }
 /// Handles a metric's lifecycle, guarding against early returns and panics.
 pub struct ExitGuard<'a, R, M: Metric<R>> {
@@ -38,11 +38,12 @@ impl<'a, R, M: Metric<R>> ExitGuard<'a, R, M> {
     }
 
     /// If no unexpected exit occurred, record the expression's result.
-    pub fn on_result(mut self, result: &mut R) {
+    pub fn on_result(mut self, result: R) -> R {
         if let Some(enter) = self.enter.take() {
-            self.metric.on_result(enter, result);
+            self.metric.on_result(enter, result).1
         } else {
             // OnResult called twice - we ignore
+            result
         }
     }
 }


### PR DESCRIPTION
This is more convenient when R is a Result<T, Wrapped<E>>, since it is easy to convert that to a Result<T, E>, but it is hard to convert the respective references.